### PR TITLE
Add the official Lamplit Labs X link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -41,6 +41,7 @@ social:
     # The first element serves as the copyright owner's link
     #- https://twitter.com/username # change to your twitter homepage
     - https://github.com/lamplitlabs # change to your github homepage
+    - https://x.com/lamplitlabs
     # Uncomment below to add more social links
     # - https://www.facebook.com/username
     - https://www.linkedin.com/company/lamplitlabs

--- a/_data/contact.yml
+++ b/_data/contact.yml
@@ -7,7 +7,10 @@
    type: instagram
    icon: 'fab fa-instagram'
    url:  'https://www.instagram.com/lamplitlabs'
-
+-
+  type: twitter
+  icon: 'fa-brands fa-x-twitter'
+  url: 'https://x.com/lamplitlabs'
 -
   type: web
   icon: 'fas fa-external-link'


### PR DESCRIPTION
## Summary
- add https://x.com/lamplitlabs exactly once to each existing organization social list touched in this repository
- leave unrelated content and repositories without social surfaces unchanged
- keep retired Mastodon and Threads account links absent

## Validation
- YAML parsing passed; Jekyll build will run in repository CI